### PR TITLE
Use artifacts volume for logs, test results, etc.

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,24 +8,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-
-    outputs:
-      build_url: ${{ steps.data.outputs.build_url }}
-
-    steps:
-      - name: Debug environment variables
-        run: env | sort
-
-      - id: data
-        name: Populates outputs
-        run: |
-          echo "build_url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
-
   build:
-    needs: setup
-
     permissions:
       contents: read
       packages: write
@@ -35,6 +18,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - id: setup
+        name: Set BUILD_URL
+        run: |
+          echo "build_url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Debug environment variables
+        run: env | sort
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -58,7 +49,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           labels: |
             edu.berkeley.lib.build-timestamp=${{ github.event.repository.updated_at }}
-            edu.berkeley.lib.build-url=${{ needs.setup.outputs.build_url }}
+            edu.berkeley.lib.build-url=${{ steps.setup.outputs.build_url }}
             edu.berkeley.lib.git-ref-name=${{ github.ref_name }}
             edu.berkeley.lib.git-repository-url=${{ github.repositoryUrl }}
             edu.berkeley.lib.git-sha=${{ github.sha }}
@@ -78,7 +69,7 @@ jobs:
           context: .
           build-args: |
             BUILD_TIMESTAMP=${{ github.event.repository.updated_at }}
-            BUILD_URL=${{ needs.setup.outputs.build_url }}
+            BUILD_URL=${{ steps.setup.outputs.build_url }}
             GIT_REF_NAME=${{ github.ref_name }}
             GIT_REPOSITORY_URL=${{ github.repositoryUrl }}
             GIT_SHA=${{ github.sha }}

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -16,10 +16,14 @@ jobs:
 
     steps:
       - name: Set the DOCKER_APP_IMAGE environment variable
-        run: echo "DOCKER_APP_IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}:sha-${GITHUB_SHA:0:7}" >> "$GITHUB_ENV"
+        shell: bash
+        run: |
+          echo "ARTIFACT_ID=${GITHUB_REPOSITORY/\//-}-sha-${GITHUB_SHA:0:7}" >> "$GITHUB_ENV"
+          echo "DOCKER_APP_IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}:sha-${GITHUB_SHA:0:7}" >> "$GITHUB_ENV"
 
       - name: Dump the environment
-        run: env | sort
+        run: |
+          env | sort
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -32,23 +36,23 @@ jobs:
 
       - name: Prepare the stack
         run: |
-          mkdir -p tmp/artifacts
           docker compose up --build --pull=always --quiet-pull --wait
+          docker compose exec -u root app chmod 0777 artifacts
           docker compose exec app setup
 
       - name: Run the test suite
-        shell: bash
         run: |
-          docker compose exec app test | tee tmp/artifacts/test-results.html
+          docker compose exec app test
 
-      - name: Write service and event logs
+      - name: Write docker service logs to a file
         if: ${{ always() }}
         run: |
-          docker compose logs > tmp/artifacts/docker-services.log
+          docker compose cp app:/opt/app/artifacts artifacts
+          docker compose logs > artifacts/docker-services.log
 
       - name: Archive test results and logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: Test Summary
-          path: tmp/artifacts
+          name: ${{ env.ARTIFACT_ID }}-artifacts
+          path: artifacts

--- a/workflow-templates/docker-ci.yml
+++ b/workflow-templates/docker-ci.yml
@@ -6,31 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  prereqs:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Check for required files
-        run: |
-          errors=0
-
-          required_files=(bin/setup bin/test docker-compose.yml docker-compose.ci.yml)
-          for file in "${required_files[@]}"; do
-            if [ -f "$file" ]; then
-              echo "$file found"
-            else
-              echo "$file not found"
-              errors=$((errors + 1))
-            fi
-          done
-
-          exit $errors
-
   build:
-    needs: prereqs
     uses: BerkeleyLibrary/.github/.github/workflows/docker-build.yml@main
 
   test:


### PR DESCRIPTION
Assumes applications are writing build artifacts to an `artifacts:/opt/app/artifacts` volume, copying that out of application containers and storing it for reference. Applications are required to implement this volume in their docker-compose.ci.yml files.